### PR TITLE
use python to send proper json

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 # Set Base Working Directory 
-basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+declare -r basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
-. "$basedir/lib/commit_summary.bash"
+. "${basedir}/lib/commit_summary.bash"
 
 echo "--- Sending Hangouts Message"
 
-WEBHOOK_URL="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_WEBHOOK_URL?}"
-CHAT_URL=${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_CHAT_ENDPOINT?}
-MESSAGE="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_MESSAGE?}"
+declare -r WEBHOOK_URL="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_WEBHOOK_URL?}"
+declare -r CHAT_URL="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_CHAT_ENDPOINT?}"
+declare -r MESSAGE="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_MESSAGE?}"
 
 if [[ "${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_DEBUG:-false}" =~ (true|on|1) ]] ; then
   echo "--- :hammer: Enabling debug mode"
@@ -19,21 +19,17 @@ fi
 
 if [[ "${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_COMMIT_SUMMARY_ENABLED:-false}" =~ (true|on|1) ]] ; then
     # Generate Commit based message
-    BK_FROM_COMMIT="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_COMMIT_SUMMARY_FROM_COMMIT}"
-    BK_TO_COMMIT="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_COMMIT_SUMMARY_TO_COMMIT}"
-    SUMMARY_LOG=$(commit_summary "$BK_FROM_COMMIT" "$BK_TO_COMMIT")
-
-    MESSAGE="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_MESSAGE} ${SUMMARY_LOG}"
+    declare -r BK_FROM_COMMIT="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_COMMIT_SUMMARY_FROM_COMMIT}"
+    declare -r BK_TO_COMMIT="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_COMMIT_SUMMARY_TO_COMMIT}"
+    declare -r SUMMARY_LOG=$(commit_summary "$BK_FROM_COMMIT" "$BK_TO_COMMIT")
+    declare -r MESSAGE="${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_MESSAGE} ${SUMMARY_LOG}"
 fi
 
-CURRENT_COMMIT=$(git rev-parse HEAD)
-THREAD_KEY=${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_THREAD_KEY:=$CURRENT_COMMIT}
+declare -r CURRENT_COMMIT=$(git rev-parse HEAD)
+declare -r THREAD_KEY=${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_THREAD_KEY:=$CURRENT_COMMIT}
 
-# # Post to Chat Service Endpoint
-curl -X "POST" "${CHAT_URL}" \
-     -H 'Content-Type: text/plain; charset=utf-8' \
-     -d $'{ "webhook": "'"${WEBHOOK_URL}"'",
-"threadkey":"'"${THREAD_KEY}"'",
-"message": "'"${MESSAGE}"'"
-}
-'
+python "${basedir}/lib/send_msg.py" \
+    --chat_url "${CHAT_URL}" \
+    --web_hook_url "${WEBHOOK_URL}"\
+    --thread_key "${THREAD_KEY}"\
+    --message "${MESSAGE}"

--- a/lib/commit_summary.bash
+++ b/lib/commit_summary.bash
@@ -2,19 +2,17 @@
 set -euo pipefail
 
 function commit_summary() {
-
-    local FROM_COMMIT="$1"
-    local TO_COMMIT="$2"
+    local FROM_COMMIT="${1}"
+    local TO_COMMIT="${2}"
 
     # print out the commits that have been added
-    git log --pretty=tformat:'`%h` %s' "$FROM".."$TO"
+    git log --pretty=tformat:'`%h` %s' "${FROM_COMMIT}".."${TO_COMMIT}"
 
     # print out the commits that have been removed
-    REMOVED_COMMITS=$(git log --pretty=tformat:'`%h` %s' "$TO".."$FROM")
-    if [ -n "$REMOVED_COMMITS" ]; then
+    declare -r REMOVED_COMMITS=$(git log --pretty=tformat:'`%h` %s' "${TO_COMMIT}".."${FROM_COMMIT}")
+    if [ -n "${REMOVED_COMMITS}" ]; then
         echo # one blank line looks a bit nicer
         echo "Removing commits"
         echo "$REMOVED_COMMITS"
     fi
-
 }

--- a/lib/send_msg.py
+++ b/lib/send_msg.py
@@ -1,0 +1,44 @@
+import argparse
+import json
+# Python 2 and 3: alternative 4
+try:
+    from urllib.parse import urlparse, urlencode
+    from urllib.request import urlopen, Request
+    from urllib.error import HTTPError
+except ImportError:
+    from urlparse import urlparse
+    from urllib import urlencode
+    from urllib2 import urlopen, Request, HTTPError
+
+ap = argparse.ArgumentParser()
+ap.add_argument('--chat_url', required=True)
+ap.add_argument('--web_hook_url', required=True)
+ap.add_argument('--thread_key', required=True)
+ap.add_argument('--message', required=True)
+args = ap.parse_args()
+
+payload = {
+    'webhook': args.web_hook_url,
+    'threadkey': args.thread_key,
+    'message': args.message
+}
+
+r = Request(
+    url=args.chat_url,
+    data=json.dumps(payload).encode(),
+    headers={
+        'Content-Type': 'application/json',
+        'charset': 'utf-8',
+    }
+)
+
+resp = urlopen(r)
+
+if resp.getcode() != 200:
+    print("failed to send notification")
+    print("endpoint status code = {}".format(resp.getcode()))
+    print("endpoint response body:")
+    print(resp.read())
+else:
+    print("notification send successfully")
+


### PR DESCRIPTION
existing curl version would throw error when message contains `"'\` where it breaks the json;

using python to send the msg so that it could escape the msg properly;

using urllib so that no 3rd lib required, also using syntax that works in both python2/3;

----
now given a msg
![image](https://user-images.githubusercontent.com/9259198/70055426-a113f300-162d-11ea-8f18-fb000bf4b1ed.png)

it will pop up as
![image](https://user-images.githubusercontent.com/9259198/70055447-a83b0100-162d-11ea-8529-28995a971789.png)
