### PR TITLE
Add runbook button for failed build

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -40,7 +40,7 @@ THREAD_KEY=${BUILDKITE_PLUGIN_HANGOUTS_NOTIFY_THREAD_KEY:=$CURRENT_COMMIT}
 
 FAIL=0
 ROWS_JSON="none"
-if [[ "${TYPE}" == "CARD'" ]]
+if [[ "${TYPE}" == "CARD" ]]
   then
 
   IFS=, read -r CARD_TITLE CARD_SUBTITLE BUILD_URL <<< "$CARD_DETAILS"
@@ -66,13 +66,15 @@ if [[ "${TYPE}" == "CARD'" ]]
 
   #Set the header icon
   HEADER_ICON='https://roktcdn1.akamaized.net/bbw/success.png'
+  BUTTONS='{"textButton":{"text":"GO TO BUILD","onClick":{"openLink":{"url":"'"$BUILD_URL"'"}}}}'
   if [ $FAIL == 1 ]
     then
       HEADER_ICON='https://roktcdn1.akamaized.net/bbw/failure.png'
+      BUTTONS=''"$BUTTONS"',{"textButton":{"text":"GO TO RUNBOOK","onClick":{"openLink":{"url":"https://github.com/ROKT/rokt-end-to-end-testing/blob/master/docs/runbook.md"}}}}'
     fi
 
   # Putting the JSON card together for hangouts
-  HANGOUTS_CARD_JSON='{"text": "'"$MESSAGE"'","cards":[{"header":{"title":"'"$CARD_TITLE"'","subtitle":"'"$CARD_SUBTITLE"'","imageUrl":"'"$HEADER_ICON"'"},"sections":[{"widgets":['"$ROWS_JSON"']},{"widgets":[{"buttons":[{"textButton":{"text":"GO TO BUILD","onClick":{"openLink":{"url":"'"$BUILD_URL"'"}}}}]}]}]}]}'
+  HANGOUTS_CARD_JSON='{"text": "'"$MESSAGE"'","cards":[{"header":{"title":"'"$CARD_TITLE"'","subtitle":"'"$CARD_SUBTITLE"'","imageUrl":"'"$HEADER_ICON"'"},"sections":[{"widgets":['"$ROWS_JSON"']},{"widgets":[{"buttons":['"$BUTTONS"']}]}]}]}'
 
   #Create webhook url based of failed tests or not
   if [ $FAIL == 1 ]


### PR DESCRIPTION
This PR introduces a "GO TO RUNBOOK" button that links to the run book page in e2e repo when there is any test failures, next to the "GO TO BUILD" button.

Also fixed the Type check by removing the single quote.

The message in gchat will look like this:
![Screenshot 2023-11-30 at 10 06 28 am](https://github.com/ROKT/hangouts-notify-buildkite-plugin/assets/87688444/a6fbaa5d-6766-4f69-9452-f10697fc7350)
