### PR TITLE
GI-5950 #16 - hangouts-notify-buildkite-plugin - Adding Cortex Service config file

### DIFF
--- a/.cortex/catalog/hangouts-notify-buildkite-plugin.yaml
+++ b/.cortex/catalog/hangouts-notify-buildkite-plugin.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: "Hangouts Notify Buildkite Plugin"
+  x-cortex-tag: "hangouts-notify-buildkite-plugin"
+  x-cortex-type: infra
+  description: |
+    A Buildkite plugin to send notifications from Buildkite to Google Hangouts
+  x-cortex-git:
+    github:
+      repository: "ROKT/hangouts-notify-buildkite-plugin"
+      basepath: "hangouts-notify-buildkite-plugin"
+  x-cortex-owners:
+    - type: group
+      name: "rokt-global-infrastructure"
+      provider: CORTEX
+  x-cortex-groups:
+    - "lang-shell"
+  x-cortex-oncall:
+    opsgenie:
+      type: SCHEDULE
+      id: "Rokt Global Infrastructure Build and Release_schedule"


### PR DESCRIPTION
### Background ###

Added Cortex Service config file. 

This is part of the below ticket to add cortex files to 44 repositories. See that list in this ticket as well as links to other PRs for similar changes in the other 43 repos in this Jira ticket: https://rokt.atlassian.net/browse/GI-5950

### What Has Changed ###

The cortex context file contains the following basic items of information which will have the configuration in a minimum state:
1. Git Repository name
2. A title
3. Description

Some of the cortex files will have the following fields (others may not):
4. Core Owners
5. Buildkite Pipeline/s
6. Main programming language used within the repo

### How Has This Been Tested? ###

It will be tested by observing the subsequent automatic creation of a Service entity in the Cortex system via the Cortex's GitOps method of Service creation which is what ROKT has set up as the official means of Service creation within our Cortex instance. 

The updated guide on Service creation in Cortex via GitOps is in this document: https://github.com/ROKT/cortex/blob/master/cortex/docs/usage.rst#onboarding-a-service

### Notes ###

Note that the presence of an incomplete Cortex file helps us (the Rokt Global Infrastructure team) programmatically and easily identify gaps in our documentation of these services. Addressing these gaps will occur in a later step which will involve the addition of information in repositories including an official CODEOWNERS file and (if appropriate) Buildkite Pipelines. 

In addition to the above items all repositories within the RGI's scope should be brought up to meet the standard details in this follow-up ticket...

https://rokt.atlassian.net/browse/GI-5951
